### PR TITLE
Fixes

### DIFF
--- a/lib/resistance/game.ex
+++ b/lib/resistance/game.ex
@@ -21,6 +21,8 @@ defmodule Game.Server do
   use GenServer
   require Logger
 
+  @quest_config %{1 => 2, 2 => 3, 3 => 2, 4 => 3, 5 => 3}
+
   @doc """
   Store game state. The state is a map with the following keys:
       players: [Player], # a list of Player, order never change during the game
@@ -43,7 +45,7 @@ defmodule Game.Server do
     GenServer.call(__MODULE__, :get_state)
   end
 
-    @doc """
+  @doc """
     check if player is in the game
   """
 
@@ -134,7 +136,7 @@ defmodule Game.Server do
       find_king(state.players).id != king_id ->
         {:reply, {:error, "You are not the king"}, state}
 
-      is_team_full(state.players, player_id) ->
+      is_team_full(state.players, player_id, get_round(state)) ->
         # 3 players already on quest and player_id is not one of them
         {:reply, {:error, "The team is full"}, state}
 
@@ -187,19 +189,24 @@ defmodule Game.Server do
     num_bad_guys = Enum.count(updated_players, fn player -> player.role == :bad end)
     num_good_guys = Enum.count(updated_players, fn player -> player.role == :good end)
 
-    new_state = cond do
-      num_bad_guys > num_good_guys ->
-        %{new_state | stage: :end_game, winning_team: :bad}
-        broadcast(:message, "Morded wins!")
-        broadcast(:update, new_state)
-        end_game()
-      num_bad_guys == 0 ->
-        %{new_state | stage: :end_game, winning_team: :good}
-        broadcast(:message, "Arthur wins!")
-        broadcast(:update, new_state)
-        end_game()
-      true -> new_state
-    end
+    new_state =
+      cond do
+        num_bad_guys > num_good_guys ->
+          %{new_state | stage: :end_game, winning_team: :bad}
+          broadcast(:message, "Morded wins!")
+          broadcast(:update, new_state)
+          end_game()
+
+        num_bad_guys == 0 ->
+          %{new_state | stage: :end_game, winning_team: :good}
+          broadcast(:message, "Arthur wins!")
+          broadcast(:update, new_state)
+          end_game()
+
+        true ->
+          new_state
+      end
+
     {:noreply, new_state}
   end
 
@@ -218,7 +225,8 @@ defmodule Game.Server do
         {:noreply, party_assembling_stage(state)}
 
       :party_assembling ->
-        if Enum.count(state.players, fn x -> x.on_quest end) == 3 do
+        if Enum.count(state.players, fn x -> x.on_quest end) ==
+             max_quest_members(get_round(state)) do
           {:noreply, voting_stage(state)}
         else
           {:noreply, clean_up(state)}
@@ -232,10 +240,12 @@ defmodule Game.Server do
         end
 
       :quest ->
-        default_votes = state.players
+        default_votes =
+          state.players
           |> Enum.filter(fn p -> p.on_quest && state.quest_votes[p.id] == nil end)
           |> Enum.map(fn p -> {p.id, :assist} end)
           |> Map.new()
+
         updated_quest_votes = Map.merge(state.quest_votes, default_votes)
         new_state = %{state | quest_votes: updated_quest_votes}
         {:noreply, quest_reveal_stage(new_state)}
@@ -244,7 +254,6 @@ defmodule Game.Server do
         {:noreply, clean_up(state)}
     end
   end
-
 
   # return a list of players, with 1/3 of them being bad and the rest being good
   defp make_players(ids_n_names) do
@@ -260,7 +269,8 @@ defmodule Game.Server do
   # assemble the party with a new king
   defp party_assembling_stage(state) do
     Logger.log(:info, "party_assembling_stage")
-    players = assign_next_king(state.players) # assign next king
+    # assign next king
+    players = assign_next_king(state.players)
     new_state = %{state | stage: :party_assembling, players: players}
     new_king = find_king(new_state.players).name
     broadcast(:message, {:server, "#{new_king} is now king!"})
@@ -271,8 +281,11 @@ defmodule Game.Server do
 
   defp voting_stage(state) do
     Logger.log(:info, "voting_stage")
-    new_state = state
-    |> Map.put(:stage, :voting)
+
+    new_state =
+      state
+      |> Map.put(:stage, :voting)
+
     broadcast(:update, new_state)
     :timer.send_after(15000, self(), {:end_stage, :voting})
     new_state
@@ -298,15 +311,18 @@ defmodule Game.Server do
   defp clean_up(%{stage: :party_assembling} = state) do
     Logger.log(:info, "clean_up")
     :timer.send_after(3000, self(), {:end_stage, :init})
+
     %{
-      players: Enum.map(state.players, fn player ->
-        %Player{player | on_quest: false} end),
+      players:
+        Enum.map(state.players, fn player ->
+          %Player{player | on_quest: false}
+        end),
       quest_outcomes: state.quest_outcomes,
       stage: :init,
       team_votes: state.team_votes,
       quest_votes: %{},
       team_rejection_count: state.team_rejection_count + 1,
-      winning_team: nil,
+      winning_team: nil
     }
   end
 
@@ -330,7 +346,7 @@ defmodule Game.Server do
           team_votes: state.team_votes,
           quest_votes: %{},
           team_rejection_count: state.team_rejection_count + 1,
-          winning_team: nil,
+          winning_team: nil
         }
     end
   end
@@ -362,7 +378,7 @@ defmodule Game.Server do
           team_votes: %{},
           quest_votes: %{},
           team_rejection_count: state.team_rejection_count,
-          winning_team: nil,
+          winning_team: nil
         }
     end
   end
@@ -408,8 +424,8 @@ defmodule Game.Server do
     Enum.find(players, fn player -> player.is_king end)
   end
 
-  defp is_team_full(players, added_player_id) do
-    Enum.count(players, fn player -> player.on_quest end) >= 3 &&
+  defp is_team_full(players, added_player_id, round) do
+    Enum.count(players, fn player -> player.on_quest end) >= max_quest_members(round) &&
       Enum.any?(players, fn player ->
         player.id == added_player_id && !player.on_quest
       end)
@@ -438,5 +454,15 @@ defmodule Game.Server do
   # Terminate server when game ends
   defp end_game() do
     GenServer.stop(__MODULE__)
+  end
+
+  # get max number of players for a quest
+  defp max_quest_members(round) do
+    Map.get(@quest_config, round, 3)
+  end
+
+  # get current round
+  defp get_round(state) do
+    length(state.quest_outcomes) + 1
   end
 end

--- a/lib/resistance/game.ex
+++ b/lib/resistance/game.ex
@@ -90,6 +90,11 @@ defmodule Game.Server do
     Phoenix.PubSub.subscribe(Resistance.PubSub, "game")
   end
 
+  # get max number of players for a quest
+  def max_quest_members(round) do
+    Map.get(@quest_config, round, 3)
+  end
+
   @impl true
 
   def init(pregame_state) do
@@ -452,11 +457,6 @@ defmodule Game.Server do
   # Terminate server when game ends
   defp end_game() do
     GenServer.stop(__MODULE__)
-  end
-
-  # get max number of players for a quest
-  defp max_quest_members(round) do
-    Map.get(@quest_config, round, 3)
   end
 
   # get current round

--- a/lib/resistance_web/components/game/side_bar.ex
+++ b/lib/resistance_web/components/game/side_bar.ex
@@ -19,6 +19,7 @@ defmodule ResistanceWeb.Game.SideBar do
           <.quest_outcomes quest_outcomes={@quest_outcomes}/>
           <.role role={@self.role} />
           <.player_list
+            round={length(@quest_outcomes) + 1}
             players={@players}
             self={@self}
             team_votes={@team_votes}
@@ -83,6 +84,7 @@ defmodule ResistanceWeb.Game.SideBar do
   Creates an interactable list of players in the game
   """
 
+  attr :round, :any, required: true
   attr :players, :any, default: []
   attr :self, Player, required: true
   attr :stage, :any, required: true
@@ -123,7 +125,7 @@ defmodule ResistanceWeb.Game.SideBar do
                 </span>
 
                 <span class="quest">
-                  <%= if @stage == :quest && p.on_quest do %>
+                  <%= if (@stage == :quest || @stage == :voting) && p.on_quest do %>
                   🏆
                   <% end %>
                 </span>
@@ -136,7 +138,7 @@ defmodule ResistanceWeb.Game.SideBar do
                   </.button>
                 <% end %>
                 <%= if !p.on_quest
-                  && Enum.count(@players, fn p -> p.on_quest end) < 3 do %>
+                  && Enum.count(@players, fn p -> p.on_quest end) < Game.Server.max_quest_members(@round) do %>
                   <.button phx-click={@on_select_player} phx-value-player={p.id}>
                     Select
                   </.button>


### PR DESCRIPTION
- Implemented variable number of quest member based on round # 
- Prevented team votes from carrying over after a failed team formation
- Show quest member emoji during voting stage
- limit # of visible select button based on rounds